### PR TITLE
Fixes for ArangoSearch Notebooks

### DIFF
--- a/notebooks/ArangoSearch.ipynb
+++ b/notebooks/ArangoSearch.ipynb
@@ -250,8 +250,7 @@
       "source": [
         "# Create an ArangoSearch view.\n",
         "database.create_arangosearch_view(\n",
-        "    name='v_imdb',\n",
-        "    properties={'cleanupIntervalStep': 0}\n",
+        "    name='v_imdb'\n",
         ")"
       ],
       "execution_count": null,

--- a/notebooks/ArangoSearchOnGraphs.ipynb
+++ b/notebooks/ArangoSearchOnGraphs.ipynb
@@ -86,7 +86,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "DyYzwbOq4g04",
-    "outputId": "f502503e-1895-4294-dc09-32e3da35d6c4"
+    "outputId": "12288fc4-5c30-4c48-ca68-b6eaf1dadb4a"
    },
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "pLkHygeug5LU",
-    "outputId": "9e96aa29-d09a-48cb-8e0c-98e253835790"
+    "outputId": "131e89ca-ef12-48e5-bf06-1bf78d4b5b64"
    },
    "outputs": [],
    "source": [
@@ -239,7 +239,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "cksnLmy44nzZ",
-    "outputId": "50e8a336-6f29-4354-b552-d6f9b8a56ac3"
+    "outputId": "4eca973b-3472-4400-b6cc-e890e96b964e"
    },
    "outputs": [],
    "source": [
@@ -274,14 +274,13 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "0QQpsU_P5CWq",
-    "outputId": "12cc245d-db9d-4dbb-8198-fe7a3ccdda08"
+    "outputId": "28b51be4-19a0-42af-c0bc-7e02c3560b47"
    },
    "outputs": [],
    "source": [
     "# Create an ArangoSearch view.\n",
     "database.create_arangosearch_view(\n",
-    "    name='v_imdb',\n",
-    "    properties={'cleanupIntervalStep': 0}\n",
+    "    name='v_imdb'\n",
     ")"
    ]
   },
@@ -302,7 +301,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "f91JRzfA5cvR",
-    "outputId": "ad224e39-a337-4054-fb22-93dbd99fe329"
+    "outputId": "7cc0ad89-8044-4f10-df4f-e6a212e2a69e"
    },
    "outputs": [],
    "source": [
@@ -369,7 +368,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "yECmzTUJV71N",
-    "outputId": "30b3b99d-5ca9-4afb-c867-dbdd58129045"
+    "outputId": "33cee9dc-2bbe-40c9-f5b8-940ab63b13b9"
    },
    "outputs": [],
    "source": [
@@ -382,7 +381,6 @@
     "   LIMIT 75 \n",
     "   FOR vertex, edge, path IN 1..1 INBOUND d imdb_edges\n",
     "     FILTER path.edges[0].$label == \"DIRECTED\"\n",
-    "     SORT score DESC\n",
     "     RETURN DISTINCT {\"director\" : vertex.name } \n",
     "\"\"\"\n",
     ")\n",

--- a/notebooks/example_output/ArangoSearchOnGraphs_output.ipynb
+++ b/notebooks/example_output/ArangoSearchOnGraphs_output.ipynb
@@ -91,7 +91,7 @@
         "!pip3 install pyarango\n",
         "!pip3 install \"python-arango>=5.0\""
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -101,7 +101,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "DyYzwbOq4g04",
-        "outputId": "f502503e-1895-4294-dc09-32e3da35d6c4"
+        "outputId": "12288fc4-5c30-4c48-ca68-b6eaf1dadb4a"
       },
       "source": [
         "import json\n",
@@ -114,7 +114,7 @@
         "from pyArango.connection import *\n",
         "from arango import ArangoClient"
       ],
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -170,13 +170,13 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "9e96aa29-d09a-48cb-8e0c-98e253835790"
+        "outputId": "131e89ca-ef12-48e5-bf06-1bf78d4b5b64"
       },
       "source": [
         "# Retrieve tmp credentials from ArangoDB Tutorial Service\n",
         "login = oasis.getTempCredentials(tutorialName=\"ArangoSearchOnGraphs\", credentialProvider=\"https://tutorials.arangodb.cloud:8529/_db/_system/tutorialDB/tutorialDB\")"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -207,7 +207,7 @@
         "# Please note that we use the python-arango driver as it has better support for ArangoSearch \n",
         "database = oasis.connect_python_arango(login)"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -225,7 +225,7 @@
         "print(\"Password: \" + login[\"password\"])\n",
         "print(\"Database: \" + login[\"dbName\"])"
       ],
-      "execution_count": 5,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -283,44 +283,44 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "50e8a336-6f29-4354-b552-d6f9b8a56ac3"
+        "outputId": "4eca973b-3472-4400-b6cc-e890e96b964e"
       },
       "source": [
         "! ./tools/arangorestore -c none --server.endpoint http+ssl://{login[\"hostname\"]}:{login[\"port\"]} --server.username {login[\"username\"]} --server.database {login[\"dbName\"]} --server.password {login[\"password\"]} --default-replication-factor 3  --input-directory \"imdb_dump\""
       ],
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "\u001b[0m2021-06-15T13:50:05Z [146] INFO [05c30] {restore} Connected to ArangoDB 'http+ssl://tutorials.arangodb.cloud:8529'\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:05Z [146] INFO [3b6a4] {restore} no properties object\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:05Z [146] INFO [9b414] {restore} # Re-creating document collection 'imdb_vertices'...\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:06Z [146] INFO [9b414] {restore} # Re-creating document collection 'Users'...\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:06Z [146] INFO [9b414] {restore} # Re-creating edge collection 'imdb_edges'...\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:07Z [146] INFO [9b414] {restore} # Re-creating edge collection 'Ratings'...\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:08Z [146] INFO [94913] {restore} # Loading data into document collection 'Users', data size: 15255 byte(s)\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:08Z [146] INFO [94913] {restore} # Loading data into document collection 'imdb_vertices', data size: 4752344 byte(s)\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:08Z [146] INFO [6d69f] {restore} # Dispatched 4 job(s), using 2 worker(s)\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:08Z [146] INFO [6ae09] {restore} # Successfully restored document collection 'Users'\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:08Z [146] INFO [94913] {restore} # Loading data into edge collection 'imdb_edges', data size: 4634754 byte(s)\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:13Z [146] INFO [75e65] {restore} # Current restore progress: restored 1 of 4 collection(s), read 25292083 byte(s) from datafiles, sent 4 data batch(es) of 8514829 byte(s) total size, queued jobs: 1, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:14Z [146] INFO [69a73] {restore} # Still loading data into document collection 'imdb_vertices', 16777216 byte(s) restored\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:15Z [146] INFO [6ae09] {restore} # Successfully restored document collection 'imdb_vertices'\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:15Z [146] INFO [94913] {restore} # Loading data into edge collection 'Ratings', data size: 1239753 byte(s)\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:18Z [146] INFO [75e65] {restore} # Current restore progress: restored 2 of 4 collection(s), read 46363374 byte(s) from datafiles, sent 7 data batch(es) of 29585981 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:23Z [146] INFO [75e65] {restore} # Current restore progress: restored 2 of 4 collection(s), read 46363374 byte(s) from datafiles, sent 7 data batch(es) of 29585981 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:25Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 16777216 byte(s) restored\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:28Z [146] INFO [75e65] {restore} # Current restore progress: restored 2 of 4 collection(s), read 59512095 byte(s) from datafiles, sent 9 data batch(es) of 46363164 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:28Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'Ratings', 13148721 byte(s) restored\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:28Z [146] INFO [6ae09] {restore} # Successfully restored edge collection 'Ratings'\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:33Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 67900703 byte(s) from datafiles, sent 10 data batch(es) of 59512062 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:38Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 67900703 byte(s) from datafiles, sent 10 data batch(es) of 59512062 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:39Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 33554432 byte(s) restored\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:43Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 76289311 byte(s) from datafiles, sent 11 data batch(es) of 67900587 byte(s) total size, queued jobs: 0, workers: 2\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:47Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 44678253 byte(s) restored\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:47Z [146] INFO [6ae09] {restore} # Successfully restored edge collection 'imdb_edges'\n",
-            "\u001b[0m\u001b[0m2021-06-15T13:50:47Z [146] INFO [a66e1] {restore} Processed 4 collection(s) in 42.007902 s, read 79024524 byte(s) from datafiles, sent 12 data batch(es) of 79024520 byte(s) total size\n",
+            "\u001b[0m2021-06-18T07:19:20Z [146] INFO [05c30] {restore} Connected to ArangoDB 'http+ssl://tutorials.arangodb.cloud:8529'\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:20Z [146] INFO [3b6a4] {restore} no properties object\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:20Z [146] INFO [9b414] {restore} # Re-creating document collection 'imdb_vertices'...\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:21Z [146] INFO [9b414] {restore} # Re-creating document collection 'Users'...\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:23Z [146] INFO [9b414] {restore} # Re-creating edge collection 'imdb_edges'...\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:24Z [146] INFO [9b414] {restore} # Re-creating edge collection 'Ratings'...\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:25Z [146] INFO [6d69f] {restore} # Dispatched 4 job(s), using 2 worker(s)\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:25Z [146] INFO [94913] {restore} # Loading data into document collection 'Users', data size: 15255 byte(s)\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:25Z [146] INFO [94913] {restore} # Loading data into document collection 'imdb_vertices', data size: 4752344 byte(s)\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:25Z [146] INFO [6ae09] {restore} # Successfully restored document collection 'Users'\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:25Z [146] INFO [94913] {restore} # Loading data into edge collection 'imdb_edges', data size: 4634754 byte(s)\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:30Z [146] INFO [75e65] {restore} # Current restore progress: restored 1 of 4 collection(s), read 25292083 byte(s) from datafiles, sent 4 data batch(es) of 8514829 byte(s) total size, queued jobs: 1, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:31Z [146] INFO [69a73] {restore} # Still loading data into document collection 'imdb_vertices', 16777216 byte(s) restored\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:33Z [146] INFO [6ae09] {restore} # Successfully restored document collection 'imdb_vertices'\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:33Z [146] INFO [94913] {restore} # Loading data into edge collection 'Ratings', data size: 1239753 byte(s)\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:35Z [146] INFO [75e65] {restore} # Current restore progress: restored 2 of 4 collection(s), read 46363374 byte(s) from datafiles, sent 7 data batch(es) of 29585981 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:38Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 16777216 byte(s) restored\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:40Z [146] INFO [75e65] {restore} # Current restore progress: restored 2 of 4 collection(s), read 59512095 byte(s) from datafiles, sent 9 data batch(es) of 46363164 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:44Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'Ratings', 13148721 byte(s) restored\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:44Z [146] INFO [6ae09] {restore} # Successfully restored edge collection 'Ratings'\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:45Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 59512095 byte(s) from datafiles, sent 9 data batch(es) of 51123461 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:50Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 67900703 byte(s) from datafiles, sent 10 data batch(es) of 59512062 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:52Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 33554432 byte(s) restored\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:19:55Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 76289311 byte(s) from datafiles, sent 11 data batch(es) of 67900587 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:20:00Z [146] INFO [75e65] {restore} # Current restore progress: restored 3 of 4 collection(s), read 79024524 byte(s) from datafiles, sent 12 data batch(es) of 76289152 byte(s) total size, queued jobs: 0, workers: 2\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:20:00Z [146] INFO [69a73] {restore} # Still loading data into edge collection 'imdb_edges', 44678253 byte(s) restored\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:20:00Z [146] INFO [6ae09] {restore} # Successfully restored edge collection 'imdb_edges'\n",
+            "\u001b[0m\u001b[0m2021-06-18T07:20:00Z [146] INFO [a66e1] {restore} Processed 4 collection(s) in 40.538428 s, read 79024524 byte(s) from datafiles, sent 12 data batch(es) of 79024520 byte(s) total size\n",
             "\u001b[0m"
           ],
           "name": "stdout"
@@ -354,22 +354,21 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "12cc245d-db9d-4dbb-8198-fe7a3ccdda08"
+        "outputId": "28b51be4-19a0-42af-c0bc-7e02c3560b47"
       },
       "source": [
         "# Create an ArangoSearch view.\n",
         "database.create_arangosearch_view(\n",
-        "    name='v_imdb',\n",
-        "    properties={'cleanupIntervalStep': 0}\n",
+        "    name='v_imdb'\n",
         ")"
       ],
-      "execution_count": 7,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "{'cleanup_interval_step': 0,\n",
+              "{'cleanup_interval_step': 2,\n",
               " 'commit_interval_msec': 1000,\n",
               " 'consolidation_interval_msec': 1000,\n",
               " 'consolidation_policy': {'min_score': 0,\n",
@@ -378,8 +377,8 @@
               "  'segments_max': 10,\n",
               "  'segments_min': 1,\n",
               "  'type': 'tier'},\n",
-              " 'global_id': 'c3749309835/',\n",
-              " 'id': '3749309835',\n",
+              " 'global_id': 'c3747358562/',\n",
+              " 'id': '3747358562',\n",
               " 'links': {},\n",
               " 'name': 'v_imdb',\n",
               " 'primary_sort': [],\n",
@@ -394,7 +393,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 7
+          "execution_count": 6
         }
       ]
     },
@@ -414,7 +413,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "ad224e39-a337-4054-fb22-93dbd99fe329"
+        "outputId": "7cc0ad89-8044-4f10-df4f-e6a212e2a69e"
       },
       "source": [
         " link = { \n",
@@ -431,13 +430,13 @@
         "    properties={'links': { 'imdb_vertices': link }}\n",
         ")"
       ],
-      "execution_count": 8,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "{'cleanup_interval_step': 0,\n",
+              "{'cleanup_interval_step': 2,\n",
               " 'commit_interval_msec': 1000,\n",
               " 'consolidation_interval_msec': 1000,\n",
               " 'consolidation_policy': {'min_score': 0,\n",
@@ -446,8 +445,8 @@
               "  'segments_max': 10,\n",
               "  'segments_min': 1,\n",
               "  'type': 'tier'},\n",
-              " 'global_id': 'c3749309835/',\n",
-              " 'id': '3749309835',\n",
+              " 'global_id': 'c3747358562/',\n",
+              " 'id': '3747358562',\n",
               " 'links': {'imdb_vertices': {'analyzers': ['identity'],\n",
               "   'fields': {'description': {'analyzers': ['text_en']},\n",
               "    'title': {'analyzers': ['text_en']}},\n",
@@ -467,7 +466,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 8
+          "execution_count": 7
         }
       ]
     },
@@ -518,7 +517,7 @@
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "30b3b99d-5ca9-4afb-c867-dbdd58129045"
+        "outputId": "33cee9dc-2bbe-40c9-f5b8-940ab63b13b9"
       },
       "source": [
         "cursor = database.aql.execute(\n",
@@ -530,7 +529,6 @@
         "   LIMIT 75 \n",
         "   FOR vertex, edge, path IN 1..1 INBOUND d imdb_edges\n",
         "     FILTER path.edges[0].$label == \"DIRECTED\"\n",
-        "     SORT score DESC\n",
         "     RETURN DISTINCT {\"director\" : vertex.name } \n",
         "\"\"\"\n",
         ")\n",
@@ -538,19 +536,20 @@
         "for doc in cursor:\n",
         "  print(doc)"
       ],
-      "execution_count": 9,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "{'director': 'Colin Strause'}\n",
             "{'director': 'Greg Strause'}\n",
+            "{'director': 'Colin Strause'}\n",
             "{'director': 'Roland Emmerich'}\n",
             "{'director': 'John Carpenter'}\n",
             "{'director': 'Phil Tippett'}\n",
             "{'director': 'Kazuhisa Takenôchi'}\n",
             "{'director': 'Richard Linklater'}\n",
             "{'director': 'Stanley Donen'}\n",
+            "{'director': 'Larry Blamire'}\n",
             "{'director': 'David Twohy'}\n",
             "{'director': 'Jae-young Kwak'}\n",
             "{'director': 'Irvin S. Yeaworth Jr.'}\n",
@@ -558,20 +557,20 @@
             "{'director': 'Chuck Russell'}\n",
             "{'director': 'Jack Sholder'}\n",
             "{'director': 'Paul McGuigan'}\n",
+            "{'director': 'Kari Skogland'}\n",
             "{'director': 'Brian Henson'}\n",
             "{'director': 'Kazuaki Kiriya'}\n",
-            "{'director': 'Michael Anderson'}\n",
             "{'director': 'Peter Yates'}\n",
             "{'director': 'Garth Jennings'}\n",
             "{'director': 'Robert C. Cooper'}\n",
             "{'director': 'Stewart Raffill'}\n",
             "{'director': 'George Lucas'}\n",
             "{'director': 'J.J. Abrams'}\n",
-            "{'director': 'P.J. Hogan'}\n",
-            "{'director': 'Rintaro'}\n",
             "{'director': 'Rupert Harvey'}\n",
             "{'director': 'Roger Vadim'}\n",
+            "{'director': 'Rintaro'}\n",
             "{'director': 'Stephen Hopkins'}\n",
+            "{'director': 'Jesse V. Johnson'}\n",
             "{'director': 'Robert Redford'}\n",
             "{'director': 'Griffin Dunne'}\n",
             "{'director': 'Dwight H. Little'}\n",
@@ -593,22 +592,20 @@
             "{'director': 'Tetsuya Nomura'}\n",
             "{'director': ' Morio Asaka'}\n",
             "{'director': 'Barry Levinson'}\n",
-            "{'director': 'Jeff Lau Chun-Wai'}\n",
             "{'director': 'Steven Spielberg'}\n",
+            "{'director': 'Jeff Lau Chun-Wai'}\n",
             "{'director': 'Chia-Liang Liu'}\n",
             "{'director': 'Mark Romanek'}\n",
             "{'director': 'Patrick Tatopoulos'}\n",
-            "{'director': 'Jeremy Kasten'}\n",
             "{'director': 'Harold Ramis'}\n",
+            "{'director': 'Jeremy Kasten'}\n",
             "{'director': 'Jim Henson'}\n",
             "{'director': 'Spike Jonze'}\n",
             "{'director': 'Matthew Robbins'}\n",
-            "{'director': 'Eric Rohmer'}\n",
             "{'director': 'Michael Crichton'}\n",
+            "{'director': 'Eric Rohmer'}\n",
             "{'director': 'Peter Mortimer'}\n",
-            "{'director': 'Josh Lowell'}\n",
-            "{'director': 'Darren Aronofsky'}\n",
-            "{'director': 'Richard Donner'}\n"
+            "{'director': 'Josh Lowell'}\n"
           ],
           "name": "stdout"
         }
@@ -677,7 +674,7 @@
         "for doc in cursor:\n",
         "  print(doc)"
       ],
-      "execution_count": 10,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -775,7 +772,7 @@
         "for doc in cursor:\n",
         "  print(doc)"
       ],
-      "execution_count": 11,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -882,7 +879,7 @@
         "for doc in cursor:\n",
         "  print(doc)"
       ],
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -964,7 +961,7 @@
         "for doc in cursor:\n",
         "  print(doc)"
       ],
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",


### PR DESCRIPTION
This PR:
- Removes an incorrect `cleanupIntervalStep` setting from both ArangoSearch notebooks
- Removes a confusing reuse of the BM25 values from the first query in the ArangoSearch Analytics notebook.

## Notebook Checklist
- [x] Add `x` to completed tasks
- [ ] `tutorialName` for temporary DB (if applicable)
- [x] Colab link added to ReadMe in the correct alphabetical order
- [x] `nbstripout` ran on notebook
- [x] Notebook with output added to the `example_output` folder with `_output` appended to filename
