### PR TITLE
docs: change the orders of the AQL tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Most notebooks were developed with Google Colab in mind and many have an [![](ht
 The following links will open the notebooks directly in Google Colab, the source files are located in [the notebooks folder](https://github.com/arangodb/interactive_tutorials/tree/master/notebooks).
 * [AQL CRUD Part 1](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlCrudTutorial.ipynb)
 * [AQL CRUD Part 2](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlPart2Tutorial.ipynb)
-* [AQL Geospatial](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlGeospatialTutorial.ipynb)
 * [AQL Joins](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlJoinTutorial.ipynb)
 * [AQL Graph Traversal](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlTraversalTutorial.ipynb)
+* [AQL Geospatial](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/AqlGeospatialTutorial.ipynb)
 * [ArangoBnB Data Preparation](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/ArangoBnB_simple_data_exploration.ipynb)
 * [ArangoSearch](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/ArangoSearch.ipynb)
 * [ArangoSearch Part 2: Advanced Graph Traversal](https://colab.research.google.com/github/arangodb/interactive_tutorials/blob/master/notebooks/ArangoSearchOnGraphs.ipynb)

--- a/notebooks/AqlGeospatialTutorial.ipynb
+++ b/notebooks/AqlGeospatialTutorial.ipynb
@@ -29,7 +29,7 @@
     "* [Part 1: CRUD](https://colab.research.google.com/github/joerg84/ArangoDBUniversity/blob/master/AqlCrudTutorial.ipynb) \n",
     "* [Part 2: Limit, Sort, Filter](https://colab.research.google.com/github/joerg84/ArangoDBUniversity/blob/master/AqlPart2Tutorial.ipynb)\n",
     "* [Part 3: Join](https://colab.research.google.com/github/joerg84/ArangoDBUniversity/blob/master/AqlJoinTutorial.ipynb)\n",
-    "* [Part 3: Graph Traversals](https://colab.research.google.com/github/joerg84/ArangoDBUniversity/blob/master/AqlTraversalTutorial.ipynb)\n",
+    "* [Part 4: Graph Traversals](https://colab.research.google.com/github/joerg84/ArangoDBUniversity/blob/master/AqlTraversalTutorial.ipynb)\n",
     "\n",
     "In this part we learn how AQL supports geospatial queries.\n",
     "Geospatial coordinates consisting of a latitude and longitude value can be stored either as two separate attributes, or as a single attribute in the form of an array with both numeric values. ArangoDB can index such coordinates for fast geospatial queries.\n",


### PR DESCRIPTION
The actual order should be:
Part 1: CRUD
Part 2: Limit, Sort, Filter
Part 3: Join
Part 3: Graph Traversals
Part 4: Geospatial Tutorial
