### PR TITLE
Fixed missing _season from query variable

### DIFF
--- a/notebooks/AqlCrudTutorial.ipynb
+++ b/notebooks/AqlCrudTutorial.ipynb
@@ -564,7 +564,7 @@
     "    RETURN {\"Name\" : c.name, \"Season\" : c.season}\n",
     "\"\"\"\n",
     "# python-arango\n",
-    "query_result = aql.execute(all_characters_names)\n",
+    "query_result = aql.execute(all_characters_names_season)\n",
     "\n",
     "# pyArango\n",
     "# query_result = pyAr_db.AQLQuery(all_characters_names_season, rawResults=True)\n",

--- a/notebooks/example_output/AqlCrudTutorial_output.ipynb
+++ b/notebooks/example_output/AqlCrudTutorial_output.ipynb
@@ -795,7 +795,7 @@
         "    RETURN {\"Name\" : c.name, \"Season\" : c.season}\n",
         "\"\"\"\n",
         "# python-arango\n",
-        "query_result = aql.execute(all_characters_names)\n",
+        "query_result = aql.execute(all_characters_names_season)\n",
         "\n",
         "# pyArango\n",
         "# query_result = pyAr_db.AQLQuery(all_characters_names_season, rawResults=True)\n",


### PR DESCRIPTION
Fixed a missing _season from the variable used in aql.execute resulting in an error.

## Notebook Checklist
- [x] Add `x` to completed tasks
- [ ] `tutorialName` for temporary DB (if applicable)
- [ ] Colab link added to ReadMe in the correct alphabetical order
- [ ] `nbstripout` ran on notebook
- [x] Notebook with output added to the `example_output` folder with `_output` appended to filename
